### PR TITLE
Support optional x264 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,15 @@ repository = "https://github.com/imager-io/ffmpeg-dev-rs"
 readme = "README.md"
 exclude = ["assets", "examples"]
 
+[features]
+default = []
+gpl = []
+x264 = ["x264-dev"]
+
 [dependencies]
 libc = "^0.2"
 num_cpus = "1.11.1"
+x264-dev = { path = "../x264-dev", optional = true }
 
 [build-dependencies]
 tar = "0.4.26"


### PR DESCRIPTION
This PR adds optional support for x264. It's disabled by default for licensing reasons, so users of this crate must opt in to x264 support by enabling the `gpl` and `x264` features.

This pull request depends on the pkgconfig manifest PR over at https://github.com/imager-io/x264-dev/pull/1