### PR TITLE
Softer bindgen dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,6 @@ num_cpus = "1.11.1"
 [build-dependencies]
 tar = "0.4.26"
 flate2 = "1.0.12"
-bindgen = "0.51"
+bindgen = ">=0.51, <0.60"
 num_cpus = "1.11.1"
 cc = "1.0.46"


### PR DESCRIPTION
Would you be open to something like this?
I'm using a few different crates (including this one, and your x264 as well), but they all depend on different version of bindgen, which means I'm forced to patch each of them individually to use the same version

I'm not sure how often (if any) breaking changes occur in bindgen, or what other problems would arise from this change?

PS: If this goes through here, I'll also open an equivalent change on x264